### PR TITLE
View Helpers

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -35,6 +35,19 @@ function getHashedAssetWithPath( $filename ) {
   return $name_with_path;
 }
 
+function getPartial( $filename ) { // with or without path
+  $clean_filename = ltrim($filename, '/views/partials/');
+  $clean_filename = rtrim($clean_filename, '.php');
+  return get_template_part('views/partials/'.$clean_filename);
+}
+
+function getView( $filename ) { // with or without path
+  $clean_filename = ltrim($filename, '/views/');
+  $clean_filename = rtrim($clean_filename, '.php');
+  return get_template_part('views/'.$clean_filename);
+}
+
+
 function getMetaTitle() {
   if (is_archive()) {
     echo post_type_archive_title() . " | ";

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -53,7 +53,6 @@ function getView( $filename ) { // with or without path
   return get_template_part('views/' . $clean_filename);
 }
 
-
 function getMetaTitle() {
   if (is_archive()) {
     echo post_type_archive_title() . " | ";

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -38,13 +38,19 @@ function getHashedAssetWithPath( $filename ) {
 function getPartial( $filename ) { // with or without path
   $clean_filename = ltrim($filename, '/views/partials/');
   $clean_filename = rtrim($clean_filename, '.php');
-  return get_template_part('views/partials/'.$clean_filename);
+  return get_template_part('views/partials/' . $clean_filename);
+}
+
+function getSvg( $filename ) { // with or without path
+  $clean_filename = ltrim($filename, '/views/partials/svg/');
+  $clean_filename = rtrim($clean_filename, '.svg');
+  return get_template_part('views/partials/svg/' . $clean_filename . '.svg');
 }
 
 function getView( $filename ) { // with or without path
   $clean_filename = ltrim($filename, '/views/');
   $clean_filename = rtrim($clean_filename, '.php');
-  return get_template_part('views/'.$clean_filename);
+  return get_template_part('views/' . $clean_filename);
 }
 
 

--- a/functions.php
+++ b/functions.php
@@ -1,8 +1,5 @@
 <?php
 
-// constants
-define('BLANKET_SVG_DIR', get_template_directory_uri() . '/views/partials/svg/');
-
 // actions & filters
 add_action('after_setup_theme', 'blanket_theme_setup');
 

--- a/functions.php
+++ b/functions.php
@@ -1,7 +1,7 @@
 <?php
 
 // constants
-define('BLANKET_SVG_DIR', get_template_directory_uri() . '/app/svg/');
+define('BLANKET_SVG_DIR', get_template_directory_uri() . '/views/partials/svg/');
 
 // actions & filters
 add_action('after_setup_theme', 'blanket_theme_setup');

--- a/views/layouts/custom.php
+++ b/views/layouts/custom.php
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html <?php language_attributes(); ?>>
-<?php get_template_part('views/partials/head') ?>
+<?php getPartial('head') ?>
 
 <body>
   <?php // visual header ?>
-  <?php get_template_part('views/partials/header') ?>
+  <?php getPartial('header') ?>
 
   <?php // page content ?>
   <div id="contentWrap">
@@ -14,9 +14,9 @@
   </div><!--contentWrap-->
 
   <?php // visual footer ?>
-  <?php get_template_part('views/partials/footer'); ?>
+  <?php getPartial('footer'); ?>
 
-  <?php // base scripts go last ?>
-  <?php get_template_part('views/partials/base'); ?>
+  <?php // base scripts got last ?>
+  <?php getPartial('base'); ?>
 </body>
 </html>

--- a/views/layouts/default.php
+++ b/views/layouts/default.php
@@ -1,22 +1,22 @@
 <!DOCTYPE html>
 <html <?php language_attributes(); ?>>
-<?php get_template_part('views/partials/head') ?>
+<?php getPartial('head') ?>
 
 <body>
   <?php // visual header ?>
-  <?php get_template_part('views/partials/header') ?>
+  <?php getPartial('header') ?>
 
   <?php // page content ?>
   <div id="contentWrap">
     <div class="content">
-      <?php get_template_part('views/home'); ?>
+      <?php getView('home'); ?>
     </div><!--content-->
   </div><!--contentWrap-->
 
   <?php // visual footer ?>
-  <?php get_template_part('views/partials/footer'); ?>
+  <?php getPartial('footer'); ?>
 
   <?php // base scripts got last ?>
-  <?php get_template_part('views/partials/base'); ?>
+  <?php getPartial('base'); ?>
 </body>
 </html>


### PR DESCRIPTION
Moves the inline-svg directory to `/views/partials`.

Adds some new helpers for views: `getPartial`, `getSvg`, `getView`.

The helpers work with or without the base file paths or file extensions:

```php
getPartial('views/partials/header.php')
// or
getPartial('header')
```